### PR TITLE
Make section number of manpage consistent with its file name

### DIFF
--- a/libusbauth-configparser/data/libusbauth-configparser.3
+++ b/libusbauth-configparser/data/libusbauth-configparser.3
@@ -1,4 +1,4 @@
-.TH USBAUTH 1
+.TH USBAUTH 3
 .SH NAME
 libusbauth-configparser \- Library for USB Firewall including flex/bison parser
 

--- a/usbauth-notifier/data/usbauth-npriv.1
+++ b/usbauth-notifier/data/usbauth-npriv.1
@@ -6,7 +6,7 @@ usbauth-notifier \- Notifier for USB Firewall to use with desktop environments
 .B usbauth-notifier
 
 .SH DESCRIPTION
-This programm is installed with SUID bit setted. The usbauth-notifier will call it to call usbauth firewall with superuser rights.
+This program is installed with SUID bit setted. The usbauth-notifier will call it to call usbauth firewall with superuser rights.
 .LP
 Example call:
 .br

--- a/usbauth-notifier/src/usbauth-npriv.c
+++ b/usbauth-notifier/src/usbauth-npriv.c
@@ -32,7 +32,7 @@
 #define BUFSIZE 128
 
 /*
- * This programm will installed with SUID bit setted
+ * This program will installed with SUID bit setted
  * The usbauth_notifier will call it to call usbauth firewall
  * with superuser rights
  *


### PR DESCRIPTION
For commit #9432019
The name of manpage is libusbauth-configparser.3, but the section numbers in the
manpage is 1 instead of 3.

According to definition of section number in manpage, it should be "3  Library calls (functions within program libraries)".

For commit #30b62f3
Fix the typo in files.