### PR TITLE
Move manpage of usbauth from section 1 to section 8

### DIFF
--- a/usbauth/data/Makefile.am
+++ b/usbauth/data/Makefile.am
@@ -9,7 +9,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-man_MANS = usbauth.1
+man_MANS = usbauth.8
 sysconf_DATA = usbauth.conf
 udevrulesdir = /lib/udev/rules.d
 dist_udevrules_DATA=20-usbauth.rules

--- a/usbauth/data/usbauth.8
+++ b/usbauth/data/usbauth.8
@@ -1,4 +1,4 @@
-.TH USBAUTH 1
+.TH USBAUTH 8
 .SH NAME
 usbauth \- USB firewall against BadUSB attacks
 

--- a/usbauth/usbauth.spec.in
+++ b/usbauth/usbauth.spec.in
@@ -84,7 +84,7 @@ autoreconf -f -i
 %config %_sysconfdir/dbus-1/system.d/org.opensuse.usbauth.conf
 %config(noreplace) %_sysconfdir/usbauth.conf
 %_udevrulesdir/20-usbauth.rules
-%_mandir/man1/usbauth.1.*
+%_mandir/man8/usbauth.8.*
 
 %if 0%{?suse_version}
 %post


### PR DESCRIPTION
Since usbauth is in /sbin which are system administration commands,
the manpage should belong in section 8 instead of 1 according to the
definition of manpage [1].

[1] https://linux.die.net/man/